### PR TITLE
add timeout option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2025-01-22
+
+### Added
+- `--timeout` command line argument to set timeout for human responses in minutes
+- Default timeout of 5 minutes for human responses
+- Autonomous decision-making guidance when timeout expires
+- AI receives instructions to delay decisions when possible or document decisions in ADR format
+
+### Changed
+- Human response waiting behavior now has configurable timeout instead of indefinite waiting
+- Updated configuration examples in README to include timeout parameter
+
+## [0.1.0] - Initial Release
+
+### Added
+- Basic Human-in-the-Loop MCP server functionality
+- Discord integration for AI-human communication
+- `ask_human` tool for AI assistants to request human input
+- Support for Claude Desktop and Claude Code integration
+- Thread-based conversation management in Discord
+- Environment variable configuration support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "human-in-the-loop"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "human-in-the-loop"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
+description = "Human-in-the-Loop MCP server that allows AI assistants to ask questions to humans via Discord"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/KOBA789/human-in-the-loop"
+homepage = "https://github.com/KOBA789/human-in-the-loop"
+readme = "README.md"
+keywords = ["mcp", "discord", "ai", "human-in-the-loop"]
+categories = ["development-tools", "web-programming"]
 
 [dependencies]
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Add the following to `claude_desktop_config.json`:
       "command": "human-in-the-loop",
       "args": [
         "--discord-channel-id", "channel-id",
-        "--discord-user-id", "user-id"
+        "--discord-user-id", "user-id",
+        "--timeout", "5"
       ],
       "env": {
         "DISCORD_TOKEN": "your-discord-bot-token"
@@ -67,7 +68,8 @@ For Claude Code (claude.ai/code), add to your MCP settings:
     "command": "human-in-the-loop",
     "args": [
       "--discord-channel-id", "channel-id",
-      "--discord-user-id", "user-id"
+      "--discord-user-id", "user-id",
+      "--timeout", "5"
     ]
   }
 }
@@ -81,6 +83,16 @@ claude
 ```
 
 Note: The server automatically reads the Discord token from the `DISCORD_TOKEN` environment variable. You can also pass it via `--discord-token` argument if needed.
+
+## Configuration
+
+### Timeout Settings
+
+The `--timeout` parameter controls how long the AI will wait for human responses (default: 5 minutes). When the timeout expires, the AI receives a message encouraging autonomous decision-making:
+
+- If decision-making can be delayed, the AI should adopt those approaches
+- If decisions must be made, the AI should document them in `./adr/yyyymmdd-hhmmss` format
+- This allows the AI to proceed autonomously when humans are unavailable
 
 ### Usage
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,8 @@ struct Args {
     discord_channel_id: ChannelId,
     #[clap(long, env = "DISCORD_USER_ID")]
     discord_user_id: UserId,
+    #[clap(long, help = "Timeout in minutes for human responses", default_value = "5")]
+    timeout: u64,
 }
 
 #[tokio::main]
@@ -32,6 +34,7 @@ async fn main() -> SdkResult<()> {
         discord_token,
         discord_channel_id,
         discord_user_id,
+        timeout,
     } = Args::parse();
 
     let server_details = InitializeResult {
@@ -59,7 +62,7 @@ async fn main() -> SdkResult<()> {
 
     let transport = StdioTransport::new(TransportOptions::default())?;
 
-    let human = HumanInDiscord::new(discord_user_id, discord_channel_id);
+    let human = HumanInDiscord::new(discord_user_id, discord_channel_id, Some(timeout));
     let discord = discord::start(&discord_token, human.handler().clone());
 
     let server: ServerRuntime =


### PR DESCRIPTION
- Add --timeout command line argument with 5 minute default
- Implement timeout logic in Discord message handling
- Return autonomous decision-making guidance on timeout
- Update documentation and version to 0.2.0